### PR TITLE
Faster topSort

### DIFF
--- a/ad.cabal
+++ b/ad.cabal
@@ -1,5 +1,5 @@
 name:         ad
-version:      1.1.1
+version:      1.1.2
 license:      BSD3
 license-File: LICENSE
 copyright:    (c) Edward Kmett 2010-2011,


### PR DESCRIPTION
Added the topSortAcyclic function that is significantly faster than Data.Graph.topSort in my limited testing, going so far as to allow large (>16k parameter) gradients to be (slowly) computed.
