### PR TITLE
Failing test for Forward.gradWith'

### DIFF
--- a/src/Numeric/AD/Mode/Forward.hs
+++ b/src/Numeric/AD/Mode/Forward.hs
@@ -184,6 +184,9 @@ gradWith g f = bindWith g (tangent . f)
 -- user-specified function.
 --
 -- Note, this performs /O(n)/ worse than 'Numeric.AD.Mode.Chain.gradWith'' for @n@ inputs, in exchange for better space utilization.
+--
+-- >>> gradWith' (,) sum [0..4]
+-- (10,[(0,1),(1,1),(2,1),(3,1),(4,1)])
 gradWith' :: (Traversable f, Num a) => (a -> a -> b) -> (forall s. Mode s => f (AD s a) -> AD s a) -> f a -> (a, f b)
 gradWith' g f = bindWith' g (tangent . f)
 {-# INLINE gradWith' #-}


### PR DESCRIPTION
If I understand correctly, Forward.gradWith' should behave like Reverse.gradWith' and return a tuple including the function's result.

I added a simple test which shows that it returns something else.

I'll keep looking to see if I could fix the bug myself but diving into your genius work seems to be over my head..

Cheers, Yair
