### PR TITLE
Add Constrained Convex Optimization

### DIFF
--- a/src/Numeric/AD/Newton.hs
+++ b/src/Numeric/AD/Newton.hs
@@ -1,8 +1,13 @@
-{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE ParallelListComp #-}
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (c) Edward Kmett 2010-2015
@@ -21,7 +26,7 @@ module Numeric.AD.Newton
   , fixedPoint
   , extremum
   -- * Gradient Ascent/Descent (Reverse AD)
-  , gradientDescent
+  , gradientDescent, constrainedDescent, CC(..), eval
   , gradientAscent
   , conjugateGradientDescent
   , conjugateGradientAscent
@@ -38,7 +43,7 @@ import Numeric.AD.Internal.Or
 import Numeric.AD.Internal.Reverse (Reverse, Tape)
 import Numeric.AD.Internal.Type (AD(..))
 import Numeric.AD.Mode
-import Numeric.AD.Mode.Reverse as Reverse (gradWith, gradWith')
+import Numeric.AD.Mode.Reverse as Reverse (gradWith, gradWith', grad')
 import Numeric.AD.Rank1.Kahn as Kahn (Kahn, grad)
 import qualified Numeric.AD.Rank1.Newton as Rank1
 import Prelude hiding (all, mapM, sum)
@@ -122,6 +127,96 @@ gradientDescent f x0 = go x0 fx0 xgx0 0.1 (0 :: Int)
         x1 = fmap (\(xi,gxi) -> xi - eta * gxi) xgx
         (fx1, xgx1) = Reverse.gradWith' (,) f x1
 {-# INLINE gradientDescent #-}
+
+data SEnv (f :: * -> *) a = SEnv { sValue :: a, origEnv :: f a }
+  deriving (Functor, Foldable, Traversable)
+
+-- | Convex constraint, CC, is a GADT wrapper that hides the existential
+-- ('s') which is so prevalent in the rest of the API.  This is an
+-- engineering convenience for managing the skolems.
+data CC f a where
+  CC :: forall f a. (forall s. Reifies s Tape => f (Reverse s a) -> Reverse s a) -> CC f a
+
+-- |@constrainedDescent obj fs env@ optimizes the convex function @obj@
+-- subject to the convex constraints @f <= 0@ where @f `elem` fs@. This is
+-- done using a log barrier to model constraints (i.e. Boyd, Chapter 11.3).
+-- The returned optimal point for the objective function must satisfy @fs@,
+-- but the initial environment, @env@, needn't be feasible.
+constrainedDescent :: forall f a. (Traversable f, RealFloat a, Floating a, Ord a)
+                   => (forall s. Reifies s Tape => f (Reverse s a)
+                                                -> Reverse s a)
+                   -> [CC f a]
+                   -> f a
+                   -> [(a,f a)]
+constrainedDescent objF [] env =
+  map (\x -> (eval objF x, x)) (gradientDescent objF env)
+constrainedDescent objF cs env =
+    let s0       = 1 + maximum [eval c env | CC c <- cs]
+        -- ^ s0 = max ( f_i(0) )
+        cs'      = [CC (\(SEnv sVal rest) -> c rest - sVal) | CC c <- cs]
+        -- ^ f_i' = f_i - s0  and thus f_i' <= 0
+        envS     = SEnv s0 env
+        -- feasible point for f_i', use gd to find feasiblity for f_i
+        getSValue (SEnv s _) = if isNaN s then 1/0 else s
+        cc       = constrainedConvex' (CC sValue) cs' envS ((<=0) . sValue)
+    in case dropWhile ((0 <) . fst) (take (2^20) cc) of
+        []                  -> []
+        (_,envFeasible) : _ ->
+            constrainedConvex' (CC objF) cs (origEnv envFeasible) (const True)
+{-# INLINE constrainedDescent #-}
+
+eval :: (Traversable f, Fractional a, Ord a) => (forall s. Reifies s Tape => f (Reverse s a) -> Reverse s a) -> f a -> a
+eval f e = fst (grad' f e)
+{-# INLINE eval #-}
+
+-- | Like 'constrainedDescent' except the initial point must be feasible.
+constrainedConvex' :: forall f a. (Traversable f, RealFloat a, Floating a, Ord a)
+                   => CC f a
+                   -> [CC f a]
+                   -> f a
+                   -> (f a -> Bool)
+                   -> [(a,f a)]
+constrainedConvex' objF cs env term =
+  -- 1. Transform cs using a log barrier with increasing t values.
+  let os   = map (mkOpt objF cs) tValues
+  -- 2. Iteratively run gradientDescent on each os.
+      envs =  [(undefined,env)] :
+              [gD (snd $ last e) o
+                          | o  <- os
+                          | e  <- limEnvs
+                          ]
+      -- Obtain a finite number of elements from the initial len tValues - 1 lists.
+      limEnvs = zipWith id nrSteps envs
+  in dropWhile (not . term . snd) (concat $ drop 1 limEnvs)
+ where
+  tValues :: [a]
+  tValues = map realToFrac $ take 64 $ iterate (*2) 2
+  nrSteps = [take 20 | _ <- [1..length tValues]] ++ [id]
+  -- | `gD f e` is gradient descent with the evaulated result
+  gD e (CC f)  = (eval f e, e) :
+                 map (\x -> (eval f x, x)) (gradientDescent f e)
+{-# INLINE constrainedConvex' #-}
+
+-- @mkOpt u fs t@ converts an inequality convex problem (@u,fs@) into an
+-- unconstrained convex problem using log barrier @u + -(1/t)log(-f_i)@.
+-- As @t@ increases the approximation is more accurate but the gradient
+-- decreases, making the gradient descent more expensive.
+mkOpt :: forall f a. (Traversable f, RealFloat a, Floating a, Ord a)
+      => CC f a -> [CC f a]
+      -> a -> CC f a
+mkOpt (CC o) xs t = CC (\e -> o e + sum (map (\(CC c) -> iHat t c e) xs))
+{-# INLINE mkOpt #-}
+
+iHat :: forall a f. (Traversable f, RealFloat a, Floating a, Ord a)
+     => a
+     -> (forall s. Reifies s Tape => f (Reverse s a) -> Reverse s a)
+     -> (forall s. Reifies s Tape => f (Reverse s a) -> Reverse s a)
+iHat t c e =
+   let r = c e
+   in if r >= 0 || isNaN r
+        then 1  / 0
+        else (-1 / auto t) * log( - (c  e))
+{-# INLINE iHat #-}
 
 -- | The 'stochasticGradientDescent' function approximates
 -- the true gradient of the constFunction by a gradient at


### PR DESCRIPTION
Currently the gradient descent function find minimums for convex problems in the form, g(x).  This patch adds a `constrainedDescent` operation that supports optimization of problems it the form `g(x) subject to f_i(x) <= 0` (for some range of `i`).

The solution method is textbook logarithmic barrier, taken straight from the Boyd book chapter 11.3.  First we find a feasible point that meets the constraints by adding in slack space and running gradient descent to minimize the slack space (till it is < 0).  Then using that feasible point we optimize the function `g x + sum (map (\f -> (1/t) * log(- (f x) ) ) fs)`.