### PR TITLE
[WIP] Implement `NoEq` variants of functions in Halley

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -121,6 +121,7 @@ The following suffixes alter the meanings of the functions above as follows:
  * `s` means the function returns all higher derivatives in a list or f-branching `Stream`
  * `T` means the result is transposed with respect to the traditional formulation (usually to avoid paying for transposing back)
  * `0` means that the resulting derivative list is padded with 0s at the end.
+ * `NoEq` means that an infinite list of converging values is returned rather than truncating the list when they become constant
 
 Contact Information
 -------------------

--- a/ad.cabal
+++ b/ad.cabal
@@ -1,5 +1,5 @@
 name:          ad
-version:       4.3.1
+version:       4.3.2
 license:       BSD3
 license-File:  LICENSE
 copyright:     (c) Edward Kmett 2010-2015,
@@ -70,6 +70,8 @@ description:
     * @T@ means the result is transposed with respect to the traditional formulation.
     .
     * @0@ means that the resulting derivative list is padded with 0s at the end.
+    .
+    * @NoEq@ means that an infinite list of converging values is returned rather than truncating the list when they become constant
 
 source-repository head
   type: git

--- a/src/Numeric/AD/Halley.hs
+++ b/src/Numeric/AD/Halley.hs
@@ -19,9 +19,13 @@ module Numeric.AD.Halley
   (
   -- * Halley's Method (Tower AD)
     findZero
+  , findZeroNoEq
   , inverse
+  , inverseNoEq
   , fixedPoint
+  , fixedPointNoEq
   , extremum
+  , extremumNoEq
   ) where
 
 import Prelude
@@ -50,6 +54,13 @@ findZero :: (Fractional a, Eq a) => (forall s. AD s (Tower a) -> AD s (Tower a))
 findZero f = Rank1.findZero (runAD.f.AD)
 {-# INLINE findZero #-}
 
+-- | The 'findZeroNoEq' function behaves the same as 'findZero' except that it
+-- doesn't truncate the list once the results become constant. This means it
+-- can be used with types without an 'Eq' instance.
+findZeroNoEq :: Fractional a => (forall s. AD s (Tower a) -> AD s (Tower a)) -> a -> [a]
+findZeroNoEq f = Rank1.findZeroNoEq (runAD.f.AD)
+{-# INLINE findZeroNoEq #-}
+
 -- | The 'inverse' function inverts a scalar function using
 -- Halley's method; its output is a stream of increasingly accurate
 -- results.  (Modulo the usual caveats.) If the stream becomes constant
@@ -60,6 +71,13 @@ findZero f = Rank1.findZero (runAD.f.AD)
 inverse :: (Fractional a, Eq a) => (forall s. AD s (Tower a) -> AD s (Tower a)) -> a -> a -> [a]
 inverse f = Rank1.inverse (runAD.f.AD)
 {-# INLINE inverse  #-}
+
+-- | The 'inverseNoEq' function behaves the same as 'inverse' except that it
+-- doesn't truncate the list once the results become constant. This means it
+-- can be used with types without an 'Eq' instance.
+inverseNoEq :: Fractional a => (forall s. AD s (Tower a) -> AD s (Tower a)) -> a -> a -> [a]
+inverseNoEq f = Rank1.inverseNoEq (runAD.f.AD)
+{-# INLINE inverseNoEq #-}
 
 -- | The 'fixedPoint' function find a fixedpoint of a scalar
 -- function using Halley's method; its output is a stream of
@@ -74,6 +92,12 @@ fixedPoint :: (Fractional a, Eq a) => (forall s. AD s (Tower a) -> AD s (Tower a
 fixedPoint f = Rank1.fixedPoint (runAD.f.AD)
 {-# INLINE fixedPoint #-}
 
+-- | The 'fixedPointNoEq' function behaves the same as 'fixedPoint' except that
+-- it doesn't truncate the list once the results become constant. This means it
+-- can be used with types without an 'Eq' instance.
+fixedPointNoEq :: Fractional a => (forall s. AD s (Tower a) -> AD s (Tower a)) -> a -> [a]
+fixedPointNoEq f = Rank1.fixedPointNoEq (runAD.f.AD)
+{-# INLINE fixedPointNoEq #-}
 
 -- | The 'extremum' function finds an extremum of a scalar
 -- function using Halley's method; produces a stream of increasingly
@@ -85,3 +109,10 @@ fixedPoint f = Rank1.fixedPoint (runAD.f.AD)
 extremum :: (Fractional a, Eq a) => (forall s. AD s (On (Forward (Tower a))) -> AD s (On (Forward (Tower a)))) -> a -> [a]
 extremum f = Rank1.extremum (runAD.f.AD)
 {-# INLINE extremum #-}
+
+-- | The 'extremumNoEq' function behaves the same as 'extremum' except that it
+-- doesn't truncate the list once the results become constant. This means it
+-- can be used with types without an 'Eq' instance.
+extremumNoEq :: Fractional a => (forall s. AD s (On (Forward (Tower a))) -> AD s (On (Forward (Tower a)))) -> a -> [a]
+extremumNoEq f = Rank1.extremumNoEq (runAD.f.AD)
+{-# INLINE extremumNoEq #-}

--- a/src/Numeric/AD/Internal/Combinators.hs
+++ b/src/Numeric/AD/Internal/Combinators.hs
@@ -16,6 +16,7 @@ module Numeric.AD.Internal.Combinators
   , zipWithDefaultT
   , withPrimal
   , fromBy
+  , takeWhileDifferent
   ) where
 
 #if __GLASGOW_HASKELL__ < 710
@@ -44,3 +45,11 @@ withPrimal t a = unary (const a) 1 t
 -- | Used internally to define various 'Enum' combinators.
 fromBy :: Jacobian t => t -> t -> Int -> Scalar t -> t
 fromBy a delta n x = binary (\_ _ -> x) 1 (fromIntegral n) a delta
+
+-- | Used internally to implement functions which truncate lists after the
+-- stream of results converge
+takeWhileDifferent :: Eq a => [a] -> [a]
+takeWhileDifferent (x1:x2:xs) = if x1 == x2
+                                  then [x1]
+                                  else x1 : takeWhileDifferent (x2:xs)
+takeWhileDifferent xs = xs

--- a/src/Numeric/AD/Newton.hs
+++ b/src/Numeric/AD/Newton.hs
@@ -23,9 +23,13 @@ module Numeric.AD.Newton
   (
   -- * Newton's Method (Forward AD)
     findZero
+  , findZeroNoEq
   , inverse
+  , inverseNoEq
   , fixedPoint
+  , fixedPointNoEq
   , extremum
+  , extremumNoEq
   -- * Gradient Ascent/Descent (Reverse AD)
   , gradientDescent, constrainedDescent, CC(..), eval
   , gradientAscent
@@ -72,6 +76,13 @@ findZero :: (Fractional a, Eq a) => (forall s. AD s (Forward a) -> AD s (Forward
 findZero f = Rank1.findZero (runAD.f.AD)
 {-# INLINE findZero #-}
 
+-- | The 'findZeroNoEq' function behaves the same as 'findZero' except that it
+-- doesn't truncate the list once the results become constant. This means it
+-- can be used with types without an 'Eq' instance.
+findZeroNoEq :: Fractional a => (forall s. AD s (Forward a) -> AD s (Forward a)) -> a -> [a]
+findZeroNoEq f = Rank1.findZeroNoEq (runAD.f.AD)
+{-# INLINE findZeroNoEq #-}
+
 -- | The 'inverse' function inverts a scalar function using
 -- Newton's method; its output is a stream of increasingly accurate
 -- results.  (Modulo the usual caveats.) If the stream becomes
@@ -84,6 +95,13 @@ findZero f = Rank1.findZero (runAD.f.AD)
 inverse :: (Fractional a, Eq a) => (forall s. AD s (Forward a) -> AD s (Forward a)) -> a -> a -> [a]
 inverse f = Rank1.inverse (runAD.f.AD)
 {-# INLINE inverse  #-}
+
+-- | The 'inverseNoEq' function behaves the same as 'inverse' except that it
+-- doesn't truncate the list once the results become constant. This means it
+-- can be used with types without an 'Eq' instance.
+inverseNoEq :: Fractional a => (forall s. AD s (Forward a) -> AD s (Forward a)) -> a -> a -> [a]
+inverseNoEq f = Rank1.inverseNoEq (runAD.f.AD)
+{-# INLINE inverseNoEq #-}
 
 -- | The 'fixedPoint' function find a fixedpoint of a scalar
 -- function using Newton's method; its output is a stream of
@@ -98,6 +116,13 @@ fixedPoint :: (Fractional a, Eq a) => (forall s. AD s (Forward a) -> AD s (Forwa
 fixedPoint f = Rank1.fixedPoint (runAD.f.AD)
 {-# INLINE fixedPoint #-}
 
+-- | The 'fixedPointNoEq' function behaves the same as 'fixedPoint' except that
+-- it doesn't truncate the list once the results become constant. This means it
+-- can be used with types without an 'Eq' instance.
+fixedPointNoEq :: Fractional a => (forall s. AD s (Forward a) -> AD s (Forward a)) -> a -> [a]
+fixedPointNoEq f = Rank1.fixedPointNoEq (runAD.f.AD)
+{-# INLINE fixedPointNoEq #-}
+
 -- | The 'extremum' function finds an extremum of a scalar
 -- function using Newton's method; produces a stream of increasingly
 -- accurate results.  (Modulo the usual caveats.) If the stream
@@ -108,6 +133,13 @@ fixedPoint f = Rank1.fixedPoint (runAD.f.AD)
 extremum :: (Fractional a, Eq a) => (forall s. AD s (On (Forward (Forward a))) -> AD s (On (Forward (Forward a)))) -> a -> [a]
 extremum f = Rank1.extremum (runAD.f.AD)
 {-# INLINE extremum #-}
+
+-- | The 'extremumNoEq' function behaves the same as 'extremum' except that it
+-- doesn't truncate the list once the results become constant. This means it
+-- can be used with types without an 'Eq' instance.
+extremumNoEq :: Fractional a => (forall s. AD s (On (Forward (Forward a))) -> AD s (On (Forward (Forward a)))) -> a -> [a]
+extremumNoEq f = Rank1.extremumNoEq (runAD.f.AD)
+{-# INLINE extremumNoEq #-}
 
 -- | The 'gradientDescent' function performs a multivariate
 -- optimization, based on the naive-gradient-descent in the file

--- a/src/Numeric/AD/Newton/Double.hs
+++ b/src/Numeric/AD/Newton/Double.hs
@@ -17,9 +17,13 @@ module Numeric.AD.Newton.Double
   (
   -- * Newton's Method (Forward AD)
     findZero
+  , findZeroNoEq
   , inverse
+  , inverseNoEq
   , fixedPoint
+  , fixedPointNoEq
   , extremum
+  , extremumNoEq
   -- * Gradient Ascent/Descent (Reverse AD)
   , conjugateGradientDescent
   , conjugateGradientAscent
@@ -51,6 +55,12 @@ findZero :: (forall s. AD s ForwardDouble -> AD s ForwardDouble) -> Double -> [D
 findZero f = Rank1.findZero (runAD.f.AD)
 {-# INLINE findZero #-}
 
+-- | The 'findZeroNoEq' function behaves the same as 'findZero' except that it
+-- doesn't truncate the list once the results become constant.
+findZeroNoEq :: (forall s. AD s ForwardDouble -> AD s ForwardDouble) -> Double -> [Double]
+findZeroNoEq f = Rank1.findZeroNoEq (runAD.f.AD)
+{-# INLINE findZeroNoEq #-}
+
 -- | The 'inverse' function inverts a scalar function using
 -- Newton's method; its output is a stream of increasingly accurate
 -- results.  (Modulo the usual caveats.) If the stream becomes
@@ -63,6 +73,12 @@ findZero f = Rank1.findZero (runAD.f.AD)
 inverse :: (forall s. AD s ForwardDouble -> AD s ForwardDouble) -> Double -> Double -> [Double]
 inverse f = Rank1.inverse (runAD.f.AD)
 {-# INLINE inverse  #-}
+
+-- | The 'inverseNoEq' function behaves the same as 'inverse' except that it
+-- doesn't truncate the list once the results become constant.
+inverseNoEq :: (forall s. AD s ForwardDouble -> AD s ForwardDouble) -> Double -> Double -> [Double]
+inverseNoEq f = Rank1.inverseNoEq (runAD.f.AD)
+{-# INLINE inverseNoEq #-}
 
 -- | The 'fixedPoint' function find a fixedpoint of a scalar
 -- function using Newton's method; its output is a stream of
@@ -77,6 +93,12 @@ fixedPoint :: (forall s. AD s ForwardDouble -> AD s ForwardDouble) -> Double -> 
 fixedPoint f = Rank1.fixedPoint (runAD.f.AD)
 {-# INLINE fixedPoint #-}
 
+-- | The 'fixedPointNoEq' function behaves the same as 'fixedPoint' except that
+-- doesn't truncate the list once the results become constant.
+fixedPointNoEq :: (forall s. AD s ForwardDouble -> AD s ForwardDouble) -> Double -> [Double]
+fixedPointNoEq f = Rank1.fixedPointNoEq (runAD.f.AD)
+{-# INLINE fixedPointNoEq #-}
+
 -- | The 'extremum' function finds an extremum of a scalar
 -- function using Newton's method; produces a stream of increasingly
 -- accurate results.  (Modulo the usual caveats.) If the stream
@@ -87,6 +109,12 @@ fixedPoint f = Rank1.fixedPoint (runAD.f.AD)
 extremum :: (forall s. AD s (On (Forward ForwardDouble)) -> AD s (On (Forward ForwardDouble))) -> Double -> [Double]
 extremum f = Rank1.extremum (runAD.f.AD)
 {-# INLINE extremum #-}
+
+-- | The 'extremumNoEq' function behaves the same as 'extremum' except that it
+-- doesn't truncate the list once the results become constant.
+extremumNoEq :: (forall s. AD s (On (Forward ForwardDouble)) -> AD s (On (Forward ForwardDouble))) -> Double -> [Double]
+extremumNoEq f = Rank1.extremumNoEq (runAD.f.AD)
+{-# INLINE extremumNoEq #-}
 
 -- | Perform a conjugate gradient descent using reverse mode automatic differentiation to compute the gradient, and using forward-on-forward mode for computing extrema.
 --

--- a/src/Numeric/AD/Rank1/Newton/Double.hs
+++ b/src/Numeric/AD/Rank1/Newton/Double.hs
@@ -17,9 +17,13 @@ module Numeric.AD.Rank1.Newton.Double
   (
   -- * Newton's Method (Forward)
     findZero
+  , findZeroNoEq
   , inverse
+  , inverseNoEq
   , fixedPoint
+  , fixedPointNoEq
   , extremum
+  , extremumNoEq
   ) where
 
 import Prelude hiding (all, mapM)
@@ -28,6 +32,7 @@ import Numeric.AD.Rank1.Forward (Forward)
 import qualified Numeric.AD.Rank1.Forward as Forward
 import Numeric.AD.Rank1.Forward.Double (ForwardDouble, diff')
 import Numeric.AD.Internal.On
+import Numeric.AD.Internal.Combinators (takeWhileDifferent)
 
 -- | The 'findZero' function finds a zero of a scalar function using
 -- Newton's method; its output is a stream of increasingly accurate
@@ -39,11 +44,17 @@ import Numeric.AD.Internal.On
 -- >>> take 10 $ findZero (\x->x^2-4) 1
 -- [1.0,2.5,2.05,2.000609756097561,2.0000000929222947,2.000000000000002,2.0]
 findZero :: (ForwardDouble -> ForwardDouble) -> Double -> [Double]
-findZero f = go where
-  go x = x : if x == xn then [] else go xn where
+findZero f = takeWhileDifferent . findZeroNoEq f
+{-# INLINE findZero #-}
+
+-- | The 'findZeroNoEq' function behaves the same as 'findZero' except that it
+-- doesn't truncate the list once the results become constant.
+findZeroNoEq :: (ForwardDouble -> ForwardDouble) -> Double -> [Double]
+findZeroNoEq f = iterate go where
+  go x = xn where
     (y,y') = diff' f x
     xn = x - y/y'
-{-# INLINE findZero #-}
+{-# INLINE findZeroNoEq #-}
 
 -- | The 'inverse' function inverts a scalar function using
 -- Newton's method; its output is a stream of increasingly accurate
@@ -55,8 +66,14 @@ findZero f = go where
 -- >>> last $ take 10 $ inverse sqrt 1 (sqrt 10)
 -- 10.0
 inverse :: (ForwardDouble -> ForwardDouble) -> Double -> Double -> [Double]
-inverse f x0 y = findZero (\x -> f x - auto y) x0
+inverse f x0 = takeWhileDifferent . inverseNoEq f x0
 {-# INLINE inverse  #-}
+
+-- | The 'inverseNoEq' function behaves the same as 'inverse' except that it
+-- doesn't truncate the list once the results become constant.
+inverseNoEq :: (ForwardDouble -> ForwardDouble) -> Double -> Double -> [Double]
+inverseNoEq f x0 y = findZeroNoEq (\x -> f x - auto y) x0
+{-# INLINE inverseNoEq #-}
 
 -- | The 'fixedPoint' function find a fixedpoint of a scalar
 -- function using Newton's method; its output is a stream of
@@ -68,8 +85,14 @@ inverse f x0 y = findZero (\x -> f x - auto y) x0
 -- >>> last $ take 10 $ fixedPoint cos 1
 -- 0.7390851332151607
 fixedPoint :: (ForwardDouble -> ForwardDouble) -> Double -> [Double]
-fixedPoint f = findZero (\x -> f x - x)
+fixedPoint f = takeWhileDifferent . fixedPointNoEq f
 {-# INLINE fixedPoint #-}
+
+-- | The 'fixedPointNoEq' function behaves the same as 'fixedPoint' except that
+-- doesn't truncate the list once the results become constant.
+fixedPointNoEq :: (ForwardDouble -> ForwardDouble) -> Double -> [Double]
+fixedPointNoEq f = findZeroNoEq (\x -> f x - x)
+{-# INLINE fixedPointNoEq #-}
 
 -- | The 'extremum' function finds an extremum of a scalar
 -- function using Newton's method; produces a stream of increasingly
@@ -79,5 +102,11 @@ fixedPoint f = findZero (\x -> f x - x)
 -- >>> last $ take 10 $ extremum cos 1
 -- 0.0
 extremum :: (On (Forward ForwardDouble) -> On (Forward ForwardDouble)) -> Double -> [Double]
-extremum f = findZero (Forward.diff (off . f . On))
+extremum f = takeWhileDifferent . extremumNoEq f
 {-# INLINE extremum #-}
+
+-- | The 'extremumNoEq' function behaves the same as 'extremum' except that it
+-- doesn't truncate the list once the results become constant.
+extremumNoEq :: (On (Forward ForwardDouble) -> On (Forward ForwardDouble)) -> Double -> [Double]
+extremumNoEq f = findZeroNoEq (Forward.diff (off . f . On))
+{-# INLINE extremumNoEq #-}


### PR DESCRIPTION
Work in progress: 
 - [x] Variants still need to be added to Newton, Newton.Double, Rank1.Newton and Rank1.Newton.Double
 - [ ] There's probably a better suffix than `NoEq` to be found

These are variants which don't require an instance for Eq on the type
being operated on so they return an infinite list of results instead.

The existing functions have been modified to call the more general NoEq
variant and truncate the list returned from that with the new function
takeWhileDifferent.