### PR TITLE
Fix multiple problems in Erf and InvErf methods

### DIFF
--- a/include/instances.h
+++ b/include/instances.h
@@ -97,9 +97,9 @@ instance BODY1(RealFrac a) => RealFrac (HEAD) where
 instance BODY1(Erf a) => Erf (HEAD) where
   erf = lift1 erf $ \x -> (2 / sqrt pi) * exp (negate x * x)
   erfc = lift1 erfc $ \x -> ((-2) / sqrt pi) * exp (negate x * x)
-  normcdf = lift1 normcdf $ \x -> ((-1) / sqrt pi) * exp (x * x * fromRational (- recip 2) / sqrt (2))
+  normcdf = lift1 normcdf $ \x -> (recip $ sqrt (2 * pi)) * exp (- x * x / 2)
 
 instance BODY1(InvErf a) => InvErf (HEAD) where
-  inverf = lift1 inverfc $ \x -> recip $ (2 / sqrt pi) * exp (negate x * x)
-  inverfc = lift1 inverfc $ \x -> recip $ negate (2 / sqrt pi) * exp (negate x * x)
-  invnormcdf = lift1 invnormcdf $ \x -> recip $ ((-1) / sqrt pi) * exp (x * x * fromRational (- recip 2) / sqrt 2)
+  inverf = lift1_ inverf $ \x _ -> sqrt pi / 2 * exp (x * x)
+  inverfc = lift1_ inverfc $ \x _ -> negate (sqrt pi / 2) * exp (x * x)
+  invnormcdf = lift1_ invnormcdf $ \x _ -> sqrt (2 * pi) * exp (x * x / 2)


### PR DESCRIPTION
This pull request fixes errors in `normcdf`, `inverf`, `inverfc` and `invnormcdf`.

## `normcdf`

By definition, `normcdf = (/2) . erfc . negate . (/sqrt 2)`. However,

```
Prelude Numeric.AD Data.Number.Erf> diff ((/2) . erfc . negate . (/sqrt 2)) 1
0.2419707245191434
Prelude Numeric.AD Data.Number.Erf> diff normcdf 1
-0.3961674381354548
```

## `inverf` etc.

`inverf . erf` and `erf . inverf` should be both identity functions (within their domain), so their derivative should be `const 1`. However,

```
Prelude Numeric.AD Data.Number.Erf> diff (inverf . erf) 1
0.7483717940991074
Prelude Numeric.AD Data.Number.Erf> diff (erf . inverf) 0.4
0.8235235351131942
```

There are similar issues with `inverfc` and `invnormcdf`.