### PR TITLE
Round the results of some floating-point doctests

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+next [????.??.??]
+-----------------
+* Make the test suite pass when built against `musl` `libc`.
+
 4.3.5 [2018.01.18]
 ------------------
 * Add `Semigroup` instance for `Id`.

--- a/ad.cabal
+++ b/ad.cabal
@@ -171,6 +171,7 @@ library
     Numeric.AD.Rank1.Tower
 
   other-modules:
+    Numeric.AD.Internal.Doctest
     Numeric.AD.Internal.Combinators
 
   ghc-options: -Wall

--- a/src/Numeric/AD.hs
+++ b/src/Numeric/AD.hs
@@ -172,6 +172,10 @@ import Numeric.AD.Mode.Sparse
 
 import Numeric.AD.Newton
 
+-- $setup
+--
+-- >>> import Numeric.AD.Internal.Doctest
+
 -- | @'hessianProduct' f wv@ computes the product of the hessian @H@ of a non-scalar-to-scalar function @f@ at @w = 'fst' <$> wv@ with a vector @v = snd <$> wv@ using \"Pearlmutter\'s method\" from <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.29.6143>, which states:
 --
 -- > H v = (d/dr) grad_w (w + r v) | r = 0
@@ -198,8 +202,8 @@ hessian f = Sparse1.jacobian (grad (off . f . fmap On))
 
 -- | Compute the order 3 Hessian tensor on a non-scalar-to-non-scalar function using 'Sparse'-on-'Reverse'
 --
--- >>> hessianF (\[x,y] -> [x*y,x+y,exp x*cos y]) [1,2]
--- [[[0.0,1.0],[1.0,0.0]],[[0.0,0.0],[0.0,0.0]],[[-1.1312043837568135,-2.4717266720048188],[-2.4717266720048188,1.1312043837568135]]]
+-- >>> hessianF (\[x,y] -> [x*y,x+y,exp x*cos y]) [1,2 :: RDouble]
+-- [[[0.0,1.0],[1.0,0.0]],[[0.0,0.0],[0.0,0.0]],[[-1.131204383757,-2.471726672005],[-2.471726672005,1.131204383757]]]
 hessianF :: (Traversable f, Functor g, Num a) => (forall s. Reifies s Tape => f (On (Reverse s (Sparse a))) -> g (On (Reverse s (Sparse a)))) -> f a -> g (f (f a))
 hessianF f as = getCompose $ Sparse1.jacobian (Compose . Reverse.jacobian (fmap off . f . fmap On)) as
 

--- a/src/Numeric/AD/Internal/Doctest.hs
+++ b/src/Numeric/AD/Internal/Doctest.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Copyright   :  (c) Edward Kmett 2010-2019
+-- License     :  BSD3
+-- Maintainer  :  ekmett@gmail.com
+-- Stability   :  experimental
+-- Portability :  GHC only
+--
+-- A version of 'Double' that rounds to the twelfth digit if necessary. This
+-- is useful for @ad@'s doctests since they must print out floating-point
+-- numbers in their entirety, but the actual numbers that get produced can
+-- vary slightly depending on machine-specific implementation details.
+-- (See #73 for an example.) This works around the issue by just rounding
+-- up the printed result to a point where it should be consistent across
+-- all machines.
+-----------------------------------------------------------------------------
+module Numeric.AD.Internal.Doctest (RDouble) where
+
+import GHC.Float
+import Numeric
+
+newtype RDouble = RDouble Double
+  deriving (Floating, Fractional, Num)
+
+instance Show RDouble where
+  showsPrec p (RDouble d)
+    | length is' >= limit
+    = showSignedFloat (showGFloat (Just limit)) p d
+    | otherwise
+    = showsPrec p d
+    where
+      limit = 12
+      (is, e) = floatToDigits 10 (abs d)
+      is' = drop e is

--- a/src/Numeric/AD/Mode/Kahn.hs
+++ b/src/Numeric/AD/Mode/Kahn.hs
@@ -55,6 +55,9 @@ import Numeric.AD.Internal.Type (AD(..))
 import Numeric.AD.Mode
 import qualified Numeric.AD.Rank1.Kahn as Rank1
 
+-- $setup
+--
+-- >>> import Numeric.AD.Internal.Doctest
 
 -- | The 'grad' function calculates the gradient of a non-scalar-to-scalar function with kahn-mode AD in a single pass.
 --
@@ -191,7 +194,7 @@ hessian f = Rank1.hessian (runAD.f.fmap AD)
 --
 -- Less efficient than 'Numeric.AD.Mode.Mixed.hessianF'.
 --
--- >>> hessianF (\[x,y] -> [x*y,x+y,exp x*cos y]) [1,2]
--- [[[0.0,1.0],[1.0,0.0]],[[0.0,0.0],[0.0,0.0]],[[-1.1312043837568135,-2.4717266720048188],[-2.4717266720048188,1.1312043837568135]]]
+-- >>> hessianF (\[x,y] -> [x*y,x+y,exp x*cos y]) [1,2 :: RDouble]
+-- [[[0.0,1.0],[1.0,0.0]],[[0.0,0.0],[0.0,0.0]],[[-1.131204383757,-2.471726672005],[-2.471726672005,1.131204383757]]]
 hessianF :: (Traversable f, Functor g, Num a) => (forall s. f (AD s (On (Kahn (Kahn a)))) -> g (AD s (On (Kahn (Kahn a))))) -> f a -> g (f (f a))
 hessianF f = Rank1.hessianF (fmap runAD.f.fmap AD)

--- a/src/Numeric/AD/Mode/Reverse.hs
+++ b/src/Numeric/AD/Mode/Reverse.hs
@@ -55,6 +55,9 @@ import Numeric.AD.Internal.On
 import Numeric.AD.Internal.Reverse
 import Numeric.AD.Mode
 
+-- $setup
+--
+-- >>> import Numeric.AD.Internal.Doctest
 
 -- | The 'grad' function calculates the gradient of a non-scalar-to-scalar function with reverse-mode AD in a single pass.
 --
@@ -202,8 +205,8 @@ hessian f = jacobian (grad (off . f . fmap On))
 --
 -- Less efficient than 'Numeric.AD.Mode.Mixed.hessianF'.
 --
--- >>> hessianF (\[x,y] -> [x*y,x+y,exp x*cos y]) [1,2]
--- [[[0.0,1.0],[1.0,0.0]],[[0.0,0.0],[0.0,0.0]],[[-1.1312043837568135,-2.4717266720048188],[-2.4717266720048188,1.1312043837568135]]]
+-- >>> hessianF (\[x,y] -> [x*y,x+y,exp x*cos y]) [1,2 :: RDouble]
+-- [[[0.0,1.0],[1.0,0.0]],[[0.0,0.0],[0.0,0.0]],[[-1.131204383757,-2.471726672005],[-2.471726672005,1.131204383757]]]
 hessianF :: (Traversable f, Functor g, Num a) => (forall s s'. (Reifies s Tape, Reifies s' Tape) => f (On (Reverse s (Reverse s' a))) -> g (On (Reverse s (Reverse s' a)))) -> f a -> g (f (f a))
 hessianF f = getCompose . jacobian (Compose . jacobian (fmap off . f . fmap On))
 {-# INLINE hessianF #-}

--- a/src/Numeric/AD/Rank1/Kahn.hs
+++ b/src/Numeric/AD/Rank1/Kahn.hs
@@ -60,6 +60,9 @@ import Numeric.AD.Internal.On
 import Numeric.AD.Internal.Kahn
 import Numeric.AD.Mode
 
+-- $setup
+--
+-- >>> import Numeric.AD.Internal.Doctest
 
 -- | The 'grad' function calculates the gradient of a non-scalar-to-scalar function with kahn-mode AD in a single pass.
 --
@@ -205,8 +208,8 @@ hessian f = jacobian (grad (off . f . fmap On))
 --
 -- Less efficient than 'Numeric.AD.Mode.Mixed.hessianF'.
 --
--- >>> hessianF (\[x,y] -> [x*y,x+y,exp x*cos y]) [1,2]
--- [[[0.0,1.0],[1.0,0.0]],[[0.0,0.0],[0.0,0.0]],[[-1.1312043837568135,-2.4717266720048188],[-2.4717266720048188,1.1312043837568135]]]
+-- >>> hessianF (\[x,y] -> [x*y,x+y,exp x*cos y]) [1,2 :: RDouble]
+-- [[[0.0,1.0],[1.0,0.0]],[[0.0,0.0],[0.0,0.0]],[[-1.131204383757,-2.471726672005],[-2.471726672005,1.131204383757]]]
 hessianF :: (Traversable f, Functor g, Num a) => (f (On (Kahn (Kahn a))) -> g (On (Kahn (Kahn a)))) -> f a -> g (f (f a))
 hessianF f = getCompose . jacobian (Compose . jacobian (fmap off . f . fmap On))
 


### PR DESCRIPTION
This should make the results consistent enough to work across multiple implementations of `libc`. Fixes #73.