### PR TITLE
exporting Numeric.AD.Jet as default to be in line with README

### DIFF
--- a/src/Numeric/AD.hs
+++ b/src/Numeric/AD.hs
@@ -129,6 +129,12 @@ module Numeric.AD
   , conjugateGradientDescent
   , conjugateGradientAscent
   , stochasticGradientDescent
+
+  -- * Working with towers
+  , Jet(..)
+  , headJet
+  , tailJet
+  , jet
   ) where
 
 import Data.Functor.Compose
@@ -143,6 +149,7 @@ import Numeric.AD.Internal.Reverse (Reverse, Tape)
 import Numeric.AD.Internal.Sparse (Sparse, Grads, vgrads)
 
 import Numeric.AD.Internal.Type
+import Numeric.AD.Jet
 import Numeric.AD.Mode
 
 import qualified Numeric.AD.Rank1.Forward as Forward1


### PR DESCRIPTION
The README has examples using `jet` without showing `Numeric.AD.Jet` being imported. Ie.:

```
Prelude Numeric.AD> headJet $ tailJet $ jet $  grads (\[x,y] -> exp (x * y)) [1,2]
[14.7781121978613,7.38905609893065]
```

This PR makes the examples work as shown. Alternatively we can change the examples to:

```
Prelude Numeric.AD Numeric.AD.Jet> headJet $ tailJet $ jet $  grads (\[x,y] -> exp (x * y)) [1,2]
[14.7781121978613,7.38905609893065]
``` 

And add `Jet` to list of modules in README.