### PR TITLE
Fix off-by-one indexing in ReverseDouble +ffi

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -238,6 +238,9 @@ jobs:
       - name: build
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
+      - name: tests
+        run: |
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
       - name: docspec
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all
@@ -257,7 +260,8 @@ jobs:
           rm -f cabal.project.local
       - name: constraint set ffi
         run: |
-          $CABAL v2-build $ARG_COMPILER --disable-tests --enable-benchmarks --constraint='ad +ffi' --dependencies-only -j2 all
-          $CABAL v2-build $ARG_COMPILER --disable-tests --enable-benchmarks --constraint='ad +ffi' all
+          $CABAL v2-build $ARG_COMPILER --enable-tests --enable-benchmarks --constraint='ad +ffi' --dependencies-only -j2 all
+          $CABAL v2-build $ARG_COMPILER --enable-tests --enable-benchmarks --constraint='ad +ffi' all
           cabal-docspec $ARG_COMPILER
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK --disable-tests --enable-benchmarks --constraint='ad +ffi' all
+          $CABAL v2-test $ARG_COMPILER --enable-tests --enable-benchmarks --constraint='ad +ffi' all
+          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK --enable-tests --enable-benchmarks --constraint='ad +ffi' all

--- a/ad.cabal
+++ b/ad.cabal
@@ -204,6 +204,14 @@ library
   ghc-options: -fspec-constr -fdicts-cheap -O2
   x-docspec-extra-packages: distributive
 
+test-suite regression
+  default-language: Haskell2010
+  type: exitcode-stdio-1.0
+  main-is: Regression.hs
+  hs-source-dirs: tests
+  build-depends: ad, base, tasty, tasty-hunit
+  ghc-options: -fspec-constr -fdicts-cheap -O2
+
 benchmark blackscholes
   default-language: Haskell2010
   type: exitcode-stdio-1.0

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -11,4 +11,6 @@ constraint-set ffi
   constraints: ad +ffi
   docspec:    True
   benchmarks: True
+  tests:      True
+  run-tests:  True
   haddock:    True

--- a/cbits/tape.c
+++ b/cbits/tape.c
@@ -104,7 +104,7 @@ void tape_backPropagate(void* p, int start, double* out)
         buffer[j] += v*y;
       }
     }
-    idx += pTape->offset;
+    idx += 1 + pTape->offset;
     pTape = pTape->prev;
   }
   

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -1,0 +1,25 @@
+module Main (main) where
+
+import qualified Numeric.AD.Mode.Reverse as R
+import qualified Numeric.AD.Mode.Reverse.Double as RD
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Regression tests"
+  [ testCase "#97" $
+      assertBool "Reverse.diff and Reverse.Double.diff should behave identically" $
+      nearZero $ R.diff f (0 :: Double) - RD.diff f (0 :: Double)
+  ]
+
+-- Reverse.Double +ffi initializes the tape with a block of size 4096
+-- The large term in this function forces the allocation of an additional block
+f :: Num a => a -> a
+f = sum . replicate 5000
+
+nearZero :: (Fractional a, Ord a) => a -> Bool
+nearZero a = abs a <= 1e-12


### PR DESCRIPTION
This is a proposed bug fix for #97.

I am still not 100% sure about the code in question, but in absence of input from the original author, this at least fixes all the problems I have observed and as far as my testing goes, does not introduce any new issues.

I have used this extensively over the last few months as part of a non-linear optimization algorithm. Of course, this is not an ideal test, as wrong gradients will simply result in subpar optimization performance, which would not be caught immediately. But at least it is some testing of the change.

Maybe it would also make sense to add the example from #97 as a regression test, but I am unfamiliar with the testing infrastructure.