### PR TITLE
Support GHC 9.6 by tightening GHC.Exts imports

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+next [????.??.??]
+-----------------
+* Support building with GHC 9.6.
+
 4.5.2 [2022.06.17]
 ------------------
 * Fix a bug that would cause `Numeric.AD.Mode.Reverse.diff` and

--- a/include/internal_kahn.h
+++ b/include/internal_kahn.h
@@ -66,7 +66,7 @@ import qualified Data.Reify.Graph as Reified
 import System.IO.Unsafe (unsafePerformIO)
 import Data.Data (Data)
 import Data.Typeable (Typeable)
-import GHC.Exts as Exts
+import qualified GHC.Exts as Exts
 import Numeric.AD.Internal.Combinators
 import Numeric.AD.Internal.Identity
 import Numeric.AD.Jacobian
@@ -255,12 +255,12 @@ partialMap = fromListWith (+) . partials
 -- strict list of scalars
 data List = Nil | Cons !SCALAR_TYPE !List
 
-instance IsList List where
+instance Exts.IsList List where
   type Item List = SCALAR_TYPE
-  fromList (x:xs) = Cons x (fromList xs)
+  fromList (x:xs) = Cons x (Exts.fromList xs)
   fromList [] = Nil
   toList Nil = []
-  toList (Cons x xs) = x : toList xs
+  toList (Cons x xs) = x : Exts.toList xs
 
 class Grad i o o' | i -> o o', o -> i o', o' -> i o where
   pack :: i -> [AD_TYPE] -> AD_TYPE


### PR DESCRIPTION
We now import `GHC.Exts` qualified in `internal_kahn.h` to ensure that `GHC.Exts`' version of `List` does not get imported and clash with the `List` types in `ad`.

Fixes #100.