### PR TITLE
Workaround for GHC 9.6.1-alpha3

### DIFF
--- a/src/Numeric/AD/Internal/On.hs
+++ b/src/Numeric/AD/Internal/On.hs
@@ -37,7 +37,7 @@ newtype On t = On { off :: t } deriving
   , InvErf, RealFloat, Typeable
   )
 
-instance (Mode t, Mode (Scalar t)) => Mode (On t) where
+instance (Mode t, Mode (Scalar t), Num (Scalar (Scalar t))) => Mode (On t) where
   type Scalar (On t) = Scalar (Scalar t)
   auto = On . auto . auto
   isKnownZero (On n) = isKnownZero n


### PR DESCRIPTION
It seems GHC 9.6.1-alpha3 becomed more strict on undecidable superclass context.
Paterson-smallness condition seems preventing infer `Num (Scalar (Scalar t))` from `Mode (Scalar t)`.
As [suggested in GHC User's Guide](https://downloads.haskell.org/ghc/9.6.1-alpha3/docs/users_guide/exts/instances.html#undecidable-instances-and-loopy-superclasses), this PR resolves this issue just by adding the seemingly derivable (but deliberately uninferred) `Num (Scalar (Scalar t))` constraint to the superclass constraints.

This fixes #102.
