### PR TITLE
Handle IEEE Floating Point Special Values

### DIFF
--- a/cbits/tape.c
+++ b/cbits/tape.c
@@ -89,6 +89,10 @@ void tape_backPropagate(void* p, int start, double* out)
     {
       double v = buffer[idx + pTape->offset];
 
+      // TODO: if we do not care about handling IEEE floating point special values (NaN, Inf) correctly
+      //       then we can skip the rest of the loop body in case v == 0
+      //       see also https://github.com/ekmett/ad/issues/106
+
       int i = pTape->lnk[idx*2];
       if (i >= 0)
       {

--- a/cbits/tape.c
+++ b/cbits/tape.c
@@ -92,17 +92,11 @@ void tape_backPropagate(void* p, int start, double* out)
 
       int i = pTape->lnk[idx*2];
       double x = pTape->val[idx*2];
-      if (x != 0.0)
-      {
-        buffer[i] += v*x;
-      }
+      if (i >= 0) buffer[i] += v*x;
 
       int j = pTape->lnk[idx*2 + 1]; 
       double y = pTape->val[idx*2 + 1];
-      if (y != 0.0)
-      {
-        buffer[j] += v*y;
-      }
+      if (j >= 0) buffer[j] += v*y;
     }
     idx += 1 + pTape->offset;
     pTape = pTape->prev;

--- a/cbits/tape.c
+++ b/cbits/tape.c
@@ -88,15 +88,20 @@ void tape_backPropagate(void* p, int start, double* out)
     while (--idx >= 0)
     {
       double v = buffer[idx + pTape->offset];
-      if (v == 0.0) continue;
 
       int i = pTape->lnk[idx*2];
-      double x = pTape->val[idx*2];
-      if (i >= 0) buffer[i] += v*x;
+      if (i >= 0)
+      {
+        double x = v * pTape->val[idx*2];
+        if (x != 0) buffer[i] += x;
+      }
 
       int j = pTape->lnk[idx*2 + 1]; 
-      double y = pTape->val[idx*2 + 1];
-      if (j >= 0) buffer[j] += v*y;
+      if (j >= 0)
+      {
+        double y = v * pTape->val[idx*2 + 1];
+        if (y != 0) buffer[j] += y;
+      }
     }
     idx += 1 + pTape->offset;
     pTape = pTape->prev;

--- a/src/Numeric/AD/Internal/Reverse/Double.hs
+++ b/src/Numeric/AD/Internal/Reverse/Double.hs
@@ -115,7 +115,7 @@ reifyTypeableTape vs k = unsafePerformIO $ fmap (\t -> reifyTypeable t k) (newTa
 -- | This is used to create a new entry on the chain given a unary function, its derivative with respect to its input,
 -- the variable ID of its input, and the value of its input. Used by 'unary' and 'binary' internally.
 unarily :: forall s. Reifies s Tape => (Double -> Double) -> Double -> Int -> Double -> ReverseDouble s
-unarily f di i b = ReverseDouble (unsafePerformIO (pushTape (Proxy :: Proxy s) i 0 di 0.0)) $! f b
+unarily f di i b = ReverseDouble (unsafePerformIO (pushTape (Proxy :: Proxy s) i (-1) di 0.0)) $! f b
 {-# INLINE unarily #-}
 
 -- | This is used to create a new entry on the chain given a binary function, its derivatives with respect to its inputs,

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -1,25 +1,116 @@
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE RankNTypes #-}
+
 module Main (main) where
 
 import qualified Numeric.AD.Mode.Reverse as R
 import qualified Numeric.AD.Mode.Reverse.Double as RD
 
+import Text.Printf
 import Test.Tasty
 import Test.Tasty.HUnit
+
+type Diff = (forall a. Floating a => a -> a) -> Double -> Double
+type Grad = (forall a. Floating a => [a] -> a) -> [Double] -> [Double]
+type Jacobian = (forall a. Floating a => [a] -> [a]) -> [Double] -> [[Double]]
+type Hessian = (forall a. Floating a => [a] -> a) -> [Double] -> [[Double]]
 
 main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
-tests = testGroup "Regression tests"
-  [ testCase "#97" $
-      assertBool "Reverse.diff and Reverse.Double.diff should behave identically" $
-      nearZero $ R.diff f (0 :: Double) - RD.diff f (0 :: Double)
-  ]
+tests = testGroup "tests" [
+  mode "reverse" R.diff R.grad R.jacobian R.hessian,
+  mode "reverse-double" RD.diff RD.grad RD.jacobian RD.hessian]
+
+mode :: String -> Diff -> Grad -> Jacobian -> Hessian -> TestTree
+mode name diff grad jacobian hessian = testGroup name [basic diff grad jacobian hessian, issue97 diff, issue104 diff grad]
+
+basic :: Diff -> Grad -> Jacobian -> Hessian -> TestTree
+basic diff grad jacobian hessian = testGroup "basic" [tdiff, tgrad, tjacobian, thessian] where
+  tdiff = testCase "diff" $ do
+    assertNearList [11, 5.5, 3, 3.5, 7, 13.5, 23, 35.5, 51] $ diff p <$> [-2, -1.5, -1, -0.5, 0, 0.5, 1, 1.5, 2]
+    assertNearList [nan, inf, 1, 0.5, 0.25] $ diff sqrt <$> [-1, 0, 0.25, 1, 4]
+    assertNearList [1, 0, 1] $ [diff sin, diff cos, diff tan] <*> [0]
+    assertNearList [-1, 0, 1] $ diff abs <$> [-1, 0, 1]
+    assertNearList [1, exp 1, inf, 1] $ [diff exp, diff log] <*> [0, 1]
+  tgrad = testCase "grad" $ do
+    assertNearList [2, 1, 1] $ grad f [1, 2, 3]
+    assertNearList [1, 0.25] $ grad h [2, 8]
+    assertNearList [0, nan] $ grad power [0, 2]
+  tjacobian = testCase "jacobian" $ do
+    assertNearMatrix [[0, 1], [1, 0], [1, 2]] $ jacobian g [2, 1]
+  thessian = testCase "hessian" $ do
+    assertNearMatrix [[0, 1, 0], [1, 0, 0], [0, 0, 0]] $ hessian f [1, 2, 3]
+    assertNearMatrix [[0, 0], [0, 0]] $ hessian sum [1, 2]
+    assertNearMatrix [[0, 1], [1, 0]] $ hessian product [1, 2]
+    assertNearMatrix [[2, 1], [1, 0]] $ hessian power [1, 2]
+  sum = \ [x, y] -> x + y
+  product = \ [x, y] -> x * y
+  power = \ [x, y] -> x ** y
+  f = \ [x, y, z] -> x * y + z
+  g = \ [x, y] -> [y, x, x * y]
+  h = \ [x, y] -> sqrt $ x * y
+  p = \ x -> 12 + 7 * x + 5 * x ^ 2 + 2 * x ^ 3
 
 -- Reverse.Double +ffi initializes the tape with a block of size 4096
 -- The large term in this function forces the allocation of an additional block
-f :: Num a => a -> a
-f = sum . replicate 5000
+issue97 :: Diff -> TestTree
+issue97 diff = testCase "issue-97" $ assertNear 5000 $ diff f 0 where f = sum . replicate 5000
 
-nearZero :: (Fractional a, Ord a) => a -> Bool
-nearZero a = abs a <= 1e-12
+issue104 :: Diff -> Grad -> TestTree
+issue104 diff grad = testGroup "issue-104" [inside, outside] where
+  inside = testGroup "inside" [tdiff, tgrad] where
+    tdiff = testCase "diff" $ do
+      assertNearList [nan, nan] $ diff (0 `f`) <$> [0, 1]
+      assertNearList [inf, 0.5] $ diff (1 `f`) <$> [0, 1]
+      assertNearList [nan, nan] $ diff (`f` 0) <$> [0, 1]
+      assertNearList [inf, 0.5] $ diff (`f` 1) <$> [0, 1]
+    tgrad = testCase "grad" $ do
+      assertNearList [nan, nan] $ grad (binary f) [0, 0]
+      assertNearList [nan, inf] $ grad (binary f) [1, 0]
+      assertNearList [inf, nan] $ grad (binary f) [0, 1]
+      assertNearList [0.5, 0.5] $ grad (binary f) [1, 1]
+    f x y = sqrt $ x * y -- grad f [x, y] = [y / (2 * f x y), x / (2 * f x y)]
+  outside = testGroup "outside" [tdiff, tgrad] where
+    tdiff = testCase "diff" $ do
+      assertNearList [nan, 0.0] $ diff (0 `f`) <$> [0, 1]
+      assertNearList [inf, 0.5] $ diff (1 `f`) <$> [0, 1]
+      assertNearList [nan, 0.0] $ diff (`f` 0) <$> [0, 1]
+      assertNearList [inf, 0.5] $ diff (`f` 1) <$> [0, 1]
+    tgrad = testCase "grad" $ do
+      assertNearList [nan, nan] $ grad (binary f) [0, 0]
+      assertNearList [0.0, inf] $ grad (binary f) [1, 0]
+      assertNearList [inf, 0.0] $ grad (binary f) [0, 1]
+      assertNearList [0.5, 0.5] $ grad (binary f) [1, 1]
+    f x y = sqrt x * sqrt y -- grad f [x, y] = [sqrt y / 2 sqrt x, sqrt x / 2 sqrt y]
+  binary f = \ [x, y] -> f x y
+
+near :: Double -> Double -> Bool
+near a b = bothNaN || bothInfinite || abs (a - b) <= 1e-12 where
+  bothNaN = isNaN a && isNaN b
+  bothInfinite = signum a == signum b && isInfinite a && isInfinite b
+
+nearList :: [Double] -> [Double] -> Bool
+nearList as bs = length as == length bs && and (zipWith near as bs)
+
+nearMatrix :: [[Double]] -> [[Double]] -> Bool
+nearMatrix as bs = length as == length bs && and (zipWith nearList as bs)
+
+assertNear :: Double -> Double -> Assertion
+assertNear a b = near a b @? expect a b
+
+assertNearList :: [Double] -> [Double] -> Assertion
+assertNearList a b = nearList a b @? expect a b
+
+assertNearMatrix :: [[Double]] -> [[Double]] -> Assertion
+assertNearMatrix a b = nearMatrix a b @? expect a b
+
+expect :: Show a => a -> a -> String
+expect a b = printf "expected %s but got %s" (show a) (show b)
+
+nan :: Double
+nan = 0 / 0
+
+inf :: Double
+inf = 1 / 0

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -20,8 +20,8 @@ main = defaultMain tests
 
 tests :: TestTree
 tests = testGroup "tests" [
-  mode "reverse" R.diff R.grad R.jacobian R.hessian,
-  mode "reverse-double" RD.diff RD.grad RD.jacobian RD.hessian]
+  mode "reverse" (\ f -> R.diff f) (\ f -> R.grad f) (\ f -> R.jacobian f) (\ f -> R.hessian f),
+  mode "reverse-double" (\ f -> RD.diff f) (\ f -> RD.grad f) (\ f -> RD.jacobian f) (\ f -> RD.hessian f)]
 
 mode :: String -> Diff -> Grad -> Jacobian -> Hessian -> TestTree
 mode name diff grad jacobian hessian = testGroup name [basic diff grad jacobian hessian, issue97 diff, issue104 diff grad]


### PR DESCRIPTION
This PR adds several changes primarily aimed at addressing issue #104.

## Expand Test Suite

I added tests for the combinators `diff`, `grad`, `jacobian`, and `hessian`. These include both basic correctness tests as well as specific regression tests for issue #104. Some of the tests were taken directly from the package documentation. For instance, the module `Numeric.AD.Mode.Reverse` lists several examples for its combinators.

The test suite is currently instantiated for the modes `Numeric.AD.Mode.Reverse` and `Numeric.AD.Mode.Reverse.Double` but could easily be extended to cover the other modes. However, there are failing tests in some of the other modes and I am not sure if adjusting those should be part of this pull request. I am also not sure if/when I will have time to look at these, so the test suite is restricted to `Numeric.AD.Mode.Reverse` and `Numeric.AD.Mode.Reverse.Double` for now.

It is worth noting that with the current setup, it is not possible to test both the pure and the `+ffi` version of `Numeric.AD.Mode.Reverse.Double` at the same time, since they are implemented within the same module and activated via preprocessor switch. This is especially troublesome since the trickier `+ffi` version is not active by default. It would be nice if the `+ffi` version could be its own module, but I do not know the rationale behind the original preprocessor switch design.

## Adjust `+ffi` Version of `Numeric.AD.Mode.Reverse.Double`

There are three changes.

1. As discussed in issue #104, the current implementation uses index `0` and value `0.0` for the unused second operand in tape entries corresponding to unary operations. I changed this to use index `-1` so that these unused operands can be distinguished from actual operands with index `0` and value `0.0`. This is a pure refactoring and should not change any behavior.
2. Instead of checking if the value of an operand is `0.0` in order to decide whether to skip this operand for backpropagation, it now checks if the index is `>= 0`. This allows processing tape entries properly in the presence of `NaN` and `Infinity` values and makes the tests `tests.reverse-double.issue-104.inside` pass. However, it no longer skips over entries where the backpropagation really would not have an effect on the partial derivative.
3. Instead of skipping the iteration if the current partial derivative is `0.0`, it now checks if the increments to each of the partial derivatives are `0.0`. This allows correct processing of `NaN` and `Infinity` values and makes the tests under `tests.reverse-double.issue-104.outside` pass. It also restores some of the skipping lost in change 2. However, there is still a performance impact compared to the original behavior of skipping the entire update if the corresponding partial derivative is `0.0`.

For the `bench/BlackScholes.hs` benchmark (adjusted for `Numeric.AD.Mode.Reverse.Double`), I was not able to measure any performance impact of these changes. For two of my own applications, I measured an increase in runtime by a factor of 1.07 and 1.21 respectively.