### PR TITLE
Add Instance Definitions for `log1p`, `expm1`, `log1pexp`, and `log1mexp`

### DIFF
--- a/include/instances.h
+++ b/include/instances.h
@@ -59,6 +59,11 @@ instance BODY1(Floating a) Floating HEAD where
   acosh    = lift1 acosh $ \x -> recip (sqrt (join (*) x - 1))
   atanh    = lift1 atanh $ \x -> recip (1 - join (*) x)
 
+  log1p    = lift1 log1p $ recip . (+) 1
+  expm1    = lift1 expm1 exp
+  log1pexp = lift1 log1pexp $ recip . (+) 1 . exp . negate
+  log1mexp = lift1 log1mexp $ recip . negate . expm1 . negate
+
 instance BODY2(Num a, Enum a) Enum HEAD where
   succ             = lift1 succ (const 1)
   pred             = lift1 pred (const 1)

--- a/include/internal_kahn.h
+++ b/include/internal_kahn.h
@@ -67,6 +67,7 @@ import System.IO.Unsafe (unsafePerformIO)
 import Data.Data (Data)
 import Data.Typeable (Typeable)
 import qualified GHC.Exts as Exts
+import Numeric
 import Numeric.AD.Internal.Combinators
 import Numeric.AD.Internal.Identity
 import Numeric.AD.Jacobian

--- a/src/Numeric/AD/Internal/Dense.hs
+++ b/src/Numeric/AD/Internal/Dense.hs
@@ -45,6 +45,7 @@ import Data.Typeable ()
 import Data.Traversable (mapAccumL)
 import Data.Data ()
 import Data.Number.Erf
+import Numeric
 import Numeric.AD.Internal.Combinators
 import Numeric.AD.Internal.Identity
 import Numeric.AD.Jacobian

--- a/src/Numeric/AD/Internal/Dense/Representable.hs
+++ b/src/Numeric/AD/Internal/Dense/Representable.hs
@@ -37,6 +37,7 @@ import Data.Functor.Rep
 import Data.Typeable ()
 import Data.Data ()
 import Data.Number.Erf
+import Numeric
 import Numeric.AD.Internal.Combinators
 import Numeric.AD.Internal.Identity
 import Numeric.AD.Jacobian

--- a/src/Numeric/AD/Internal/Forward.hs
+++ b/src/Numeric/AD/Internal/Forward.hs
@@ -41,6 +41,7 @@ import Data.Foldable (toList)
 import Data.Traversable (mapAccumL)
 import Data.Data
 import Data.Number.Erf
+import Numeric
 import Numeric.AD.Internal.Combinators
 import Numeric.AD.Internal.Identity
 import Numeric.AD.Jacobian

--- a/src/Numeric/AD/Internal/Forward/Double.hs
+++ b/src/Numeric/AD/Internal/Forward/Double.hs
@@ -37,6 +37,7 @@ import Data.Foldable (toList)
 import Data.Traversable (mapAccumL)
 import Control.Monad (join)
 import Data.Number.Erf
+import Numeric
 import Numeric.AD.Internal.Combinators
 import Numeric.AD.Internal.Identity
 import Numeric.AD.Jacobian

--- a/src/Numeric/AD/Internal/Kahn.hs
+++ b/src/Numeric/AD/Internal/Kahn.hs
@@ -62,6 +62,7 @@ import qualified Data.Reify.Graph as Reified
 import System.IO.Unsafe (unsafePerformIO)
 import Data.Data (Data)
 import Data.Typeable (Typeable)
+import Numeric
 import Numeric.AD.Internal.Combinators
 import Numeric.AD.Internal.Identity
 import Numeric.AD.Jacobian

--- a/src/Numeric/AD/Internal/Reverse.hs
+++ b/src/Numeric/AD/Internal/Reverse.hs
@@ -66,6 +66,7 @@ import Data.Proxy
 import Data.Reflection
 import Data.Traversable (mapM)
 import Data.Typeable
+import Numeric
 import Numeric.AD.Internal.Combinators
 import Numeric.AD.Internal.Identity
 import Numeric.AD.Jacobian

--- a/src/Numeric/AD/Internal/Reverse/Double.hs
+++ b/src/Numeric/AD/Internal/Reverse/Double.hs
@@ -60,6 +60,7 @@ import Data.Proxy
 import Data.Reflection
 import Data.Traversable (mapM)
 import Data.Typeable
+import Numeric
 import Numeric.AD.Internal.Combinators
 import Numeric.AD.Internal.Identity
 import Numeric.AD.Jacobian

--- a/src/Numeric/AD/Internal/Sparse.hs
+++ b/src/Numeric/AD/Internal/Sparse.hs
@@ -52,6 +52,7 @@ import qualified Data.IntMap as IntMap
 import Data.Number.Erf
 import Data.Traversable
 import Data.Typeable ()
+import Numeric
 import Numeric.AD.Internal.Combinators
 import Numeric.AD.Internal.Sparse.Common
 import Numeric.AD.Jacobian

--- a/src/Numeric/AD/Internal/Sparse/Double.hs
+++ b/src/Numeric/AD/Internal/Sparse/Double.hs
@@ -52,6 +52,7 @@ import qualified Data.IntMap as IntMap
 import Data.Number.Erf
 import Data.Traversable
 import Data.Typeable ()
+import Numeric
 import Numeric.AD.Internal.Combinators
 import Numeric.AD.Internal.Sparse.Common
 import Numeric.AD.Jacobian

--- a/src/Numeric/AD/Internal/Tower.hs
+++ b/src/Numeric/AD/Internal/Tower.hs
@@ -40,6 +40,7 @@ import Data.Foldable
 import Data.Data (Data)
 import Data.Number.Erf
 import Data.Typeable (Typeable)
+import Numeric
 import Numeric.AD.Internal.Combinators
 import Numeric.AD.Jacobian
 import Numeric.AD.Mode

--- a/src/Numeric/AD/Internal/Tower/Double.hs
+++ b/src/Numeric/AD/Internal/Tower/Double.hs
@@ -46,6 +46,7 @@ import Data.Foldable
 import Data.Data (Data)
 import Data.Number.Erf
 import Data.Typeable (Typeable)
+import Numeric
 import Numeric.AD.Internal.Combinators
 import Numeric.AD.Jacobian
 import Numeric.AD.Mode

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -131,6 +131,7 @@ issue108 diff = testGroup "issue-108" [tlog1p, texpm1, tlog1pexp, tlog1mexp] whe
     equal (-2.3521684610440907, -9.50833194477505) $ diff log1mexp (-0.1)
     equal (-34.538776394910684, -9.999999999999994e14) $ diff log1mexp (-1e-15)
     equal (-46.051701859880914, -1e20) $ diff log1mexp (-1e-20)
+    equal (-inf, -inf) $ diff log1mexp (-0)
   equal = expect $ \ (a, b) (c, d) -> eq a c && eq b d
 
 -- TODO: ideally, we would consider `0` and `-0` to be different

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -125,7 +126,11 @@ issue108 diff = testGroup "issue-108" [tlog1p, texpm1, tlog1pexp, tlog1mexp] whe
     equal (1000, 1) $ diff log1pexp 1000
   tlog1mexp = testCase "log1mexp" $ do
     equal (-0, -0) $ diff log1mexp (-1000)
+-- old versions of base have a faulty implementation of log1mexp, causing this case to fail
+-- see also https://gitlab.haskell.org/ghc/ghc/-/issues/17125
+#if MIN_VERSION_base(4, 13, 0)
     equal (-3.720075976020836e-44, -3.7200759760208356e-44) $ diff log1mexp (-100)
+#endif
     equal (-0.45867514538708193, -0.5819767068693265) $ diff log1mexp (-1)
     equal (-0.9327521295671886, -1.5414940825367982) $ diff log1mexp (-0.5)
     equal (-2.3521684610440907, -9.50833194477505) $ diff log1mexp (-0.1)


### PR DESCRIPTION
This PR addresses #108. It builds on #110.

The derivatives for `log1p` and `expm1` are pretty much the straightforward ones.

For `log1pexp`, we can do some adjustments to improve numerical stability:
```hs
f x = log (1 + exp x)
f' x = exp x / (1 + exp x) = 1 / (1 + exp (-x))
```

For `log1mexp`, we can do something even more clever:
```hs
f x = log (1 - exp x)
f' x = - exp x / (1 - exp x) = 1 / (1 - exp (-x)) = 1 / (- expm1 (-x))
```

In the end, I added the following instance definitions for the extra floating point functions:
```hs
log1p    = lift1 log1p $ recip . (+) 1
expm1    = lift1 expm1 exp
log1pexp = lift1 log1pexp $ recip . (+) 1 . exp . negate
log1mexp = lift1 log1mexp $ recip . negate . expm1 . negate
```

It would be nice if someone could double-check these for both correctness and considerations of numerical stability.

I also added some regression tests on these functions and their derivatives both for normal and extreme values where the previous default implementation were failing.