### PR TITLE
Use Relative Error for Equality Comparison in Tests

### DIFF
--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -142,16 +142,16 @@ issue108 diff = testGroup "issue-108" [tlog1p, texpm1, tlog1pexp, tlog1mexp] whe
 --       however, zero signedness is currently not reliably propagated through some modes
 --       see also https://github.com/ekmett/ad/issues/109 and https://github.com/ekmett/ad/pull/110
 eq :: Double -> Double -> Bool
-eq a b = isNaN a && isNaN b || a == b
+eq expected actual = isNaN expected && isNaN actual || expected == actual
 
 pair :: (a -> a -> Bool) -> (a, a) -> (a, a) -> Bool
-pair eq (a, b) (c, d) = eq a c && eq b d
+pair eq (expected1, expected2) (actual1, actual2) = eq expected1 actual1 && eq expected2 actual2
 
 list :: (a -> a -> Bool) -> [a] -> [a] -> Bool
-list eq as bs = length as == length bs && and (zipWith eq as bs)
+list eq expected actual = length expected == length actual && and (zipWith eq expected actual)
 
 expect :: HasCallStack => Show a => (a -> a -> Bool) -> a -> a -> Assertion
-expect eq a b = eq a b @? printf "expected %s but got %s" (show a) (show b)
+expect eq expected actual = eq expected actual @? printf "expected %s but got %s" (show expected) (show actual)
 
 nan :: Double
 nan = 0 / 0

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -101,49 +101,51 @@ issue104 diff grad = testGroup "issue-104" [inside, outside] where
 issue108 :: Diff' -> TestTree
 issue108 diff = testGroup "issue-108" [tlog1p, texpm1, tlog1pexp, tlog1mexp] where
   tlog1p = testCase "log1p" $ do
-    equal (-inf, inf) $ diff log1p (-1)
-    equal (-1.0000000000000007e-15, 1.000000000000001) $ diff log1p (-1e-15)
-    equal (-1e-20, 1) $ diff log1p (-1e-20)
-    equal (0, 1) $ diff log1p 0
-    equal (1e-20, 1) $ diff log1p 1e-20
-    equal (9.999999999999995e-16, 0.9999999999999989) $ diff log1p 1e-15
-    equal (0.6931471805599453, 0.5) $ diff log1p 1
+    expect (pair eq) (-inf, inf) $ diff log1p (-1)
+    expect (pair eq) (-1.0000000000000007e-15, 1.000000000000001) $ diff log1p (-1e-15)
+    expect (pair eq) (-1e-20, 1) $ diff log1p (-1e-20)
+    expect (pair eq) (0, 1) $ diff log1p 0
+    expect (pair eq) (1e-20, 1) $ diff log1p 1e-20
+    expect (pair eq) (9.999999999999995e-16, 0.9999999999999989) $ diff log1p 1e-15
+    expect (pair eq) (0.6931471805599453, 0.5) $ diff log1p 1
   texpm1 = testCase "expm1" $ do
-    equal (-0.6321205588285577, 0.36787944117144233) $ diff expm1 (-1)
-    equal (-9.999999999999995e-16, 0.999999999999999) $ diff expm1 (-1e-15)
-    equal (-1e-20, 1) $ diff expm1 (-1e-20)
-    equal (0, 1) $ diff expm1 0
-    equal (1e-20, 1) $ diff expm1 1e-20
-    equal (1.0000000000000007e-15, 1.000000000000001) $ diff expm1 1e-15
-    equal (1.718281828459045, 2.718281828459045) $ diff expm1 1
+    expect (pair eq) (-0.6321205588285577, 0.36787944117144233) $ diff expm1 (-1)
+    expect (pair eq) (-9.999999999999995e-16, 0.999999999999999) $ diff expm1 (-1e-15)
+    expect (pair eq) (-1e-20, 1) $ diff expm1 (-1e-20)
+    expect (pair eq) (0, 1) $ diff expm1 0
+    expect (pair eq) (1e-20, 1) $ diff expm1 1e-20
+    expect (pair eq) (1.0000000000000007e-15, 1.000000000000001) $ diff expm1 1e-15
+    expect (pair eq) (1.718281828459045, 2.718281828459045) $ diff expm1 1
   tlog1pexp = testCase "log1pexp" $ do
-    equal (0, 0) $ diff log1pexp (-1000)
-    equal (3.720075976020836e-44, 3.7200759760208356e-44) $ diff log1pexp (-100)
-    equal (0.31326168751822286, 0.2689414213699951) $ diff log1pexp (-1)
-    equal (0.6931471805599453, 0.5) $ diff log1pexp 0
-    equal (1.3132616875182228, 0.7310585786300049) $ diff log1pexp 1
-    equal (100, 1) $ diff log1pexp 100
-    equal (1000, 1) $ diff log1pexp 1000
+    expect (pair eq) (0, 0) $ diff log1pexp (-1000)
+    expect (pair eq) (3.720075976020836e-44, 3.7200759760208356e-44) $ diff log1pexp (-100)
+    expect (pair eq) (0.31326168751822286, 0.2689414213699951) $ diff log1pexp (-1)
+    expect (pair eq) (0.6931471805599453, 0.5) $ diff log1pexp 0
+    expect (pair eq) (1.3132616875182228, 0.7310585786300049) $ diff log1pexp 1
+    expect (pair eq) (100, 1) $ diff log1pexp 100
+    expect (pair eq) (1000, 1) $ diff log1pexp 1000
   tlog1mexp = testCase "log1mexp" $ do
-    equal (-0, -0) $ diff log1mexp (-1000)
+    expect (pair eq) (-0, -0) $ diff log1mexp (-1000)
 -- old versions of base have a faulty implementation of log1mexp, causing this case to fail
 -- see also https://gitlab.haskell.org/ghc/ghc/-/issues/17125
 #if MIN_VERSION_base(4, 13, 0)
-    equal (-3.720075976020836e-44, -3.7200759760208356e-44) $ diff log1mexp (-100)
+    expect (pair eq) (-3.720075976020836e-44, -3.7200759760208356e-44) $ diff log1mexp (-100)
 #endif
-    equal (-0.45867514538708193, -0.5819767068693265) $ diff log1mexp (-1)
-    equal (-0.9327521295671886, -1.5414940825367982) $ diff log1mexp (-0.5)
-    equal (-2.3521684610440907, -9.50833194477505) $ diff log1mexp (-0.1)
-    equal (-34.538776394910684, -9.999999999999994e14) $ diff log1mexp (-1e-15)
-    equal (-46.051701859880914, -1e20) $ diff log1mexp (-1e-20)
-    equal (-inf, -inf) $ diff log1mexp (-0)
-  equal = expect $ \ (a, b) (c, d) -> eq a c && eq b d
+    expect (pair eq) (-0.45867514538708193, -0.5819767068693265) $ diff log1mexp (-1)
+    expect (pair eq) (-0.9327521295671886, -1.5414940825367982) $ diff log1mexp (-0.5)
+    expect (pair eq) (-2.3521684610440907, -9.50833194477505) $ diff log1mexp (-0.1)
+    expect (pair eq) (-34.538776394910684, -9.999999999999994e14) $ diff log1mexp (-1e-15)
+    expect (pair eq) (-46.051701859880914, -1e20) $ diff log1mexp (-1e-20)
+    expect (pair eq) (-inf, -inf) $ diff log1mexp (-0)
 
 -- TODO: ideally, we would consider `0` and `-0` to be different
 --       however, zero signedness is currently not reliably propagated through some modes
 --       see also https://github.com/ekmett/ad/issues/109 and https://github.com/ekmett/ad/pull/110
 eq :: Double -> Double -> Bool
 eq a b = isNaN a && isNaN b || a == b
+
+pair :: (a -> a -> Bool) -> (a, a) -> (a, a) -> Bool
+pair eq (a, b) (c, d) = eq a c && eq b d
 
 list :: (a -> a -> Bool) -> [a] -> [a] -> Bool
 list eq as bs = length as == length bs && and (zipWith eq as bs)

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -142,7 +142,10 @@ issue108 diff = testGroup "issue-108" [tlog1p, texpm1, tlog1pexp, tlog1mexp] whe
 --       however, zero signedness is currently not reliably propagated through some modes
 --       see also https://github.com/ekmett/ad/issues/109 and https://github.com/ekmett/ad/pull/110
 eq :: Double -> Double -> Bool
-eq expected actual = isNaN expected && isNaN actual || expected == actual
+eq expected actual
+  | isNaN expected = isNaN actual
+  | isInfinite expected = isInfinite actual && signum actual == signum expected
+  | otherwise = abs (actual - expected) <= 1e-12 * abs expected
 
 pair :: (a -> a -> Bool) -> (a, a) -> (a, a) -> Bool
 pair eq (expected1, expected2) (actual1, actual2) = eq expected1 actual1 && eq expected2 actual2


### PR DESCRIPTION
In order to make the tests more robust, we use relative error for equality comparison instead of absolute error or exact comparison. This should fix #113, but I do not have a `x86_64-darwin` setup to test this.

I also did some cleanup first, I can split that part off into a separate PR if necessary.